### PR TITLE
Exit tsc-files with tsc's status

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ const tmpTsconfig = {
 fs.writeFileSync(tmpTsconfigPath, JSON.stringify(tmpTsconfig, null, 2))
 
 // Type-check our files
-spawnSync(
+const { status } = spawnSync(
   resolveFromModule('typescript', 'bin/tsc'),
   ['-p', tmpTsconfigPath, '--noEmit'],
   { stdio: 'inherit' },
@@ -40,3 +40,4 @@ spawnSync(
 
 // Delete temp config file
 fs.unlinkSync(tmpTsconfigPath)
+process.exit(status);

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,4 +40,5 @@ const { status } = spawnSync(
 
 // Delete temp config file
 fs.unlinkSync(tmpTsconfigPath)
+
 process.exit(status);


### PR DESCRIPTION
Currently when the provided file contains type errors, `tsc` do exit with status 1 but `tsc-file` exits with status 0. This does not stop CI nor lint-staged.

This PR reads `tsc`'s exit status and invokes `process.exit` with the status.