### PR TITLE
Ignore include

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@ const { randomChars, resolveFromModule, resolveFromRoot } = require('./utils')
 const args = process.argv.slice(2)
 const argsProjectIndex = args.findIndex(arg => ['-p', '--project'].includes(arg)) // prettier-ignore
 const argsProjectValue = argsProjectIndex !== -1 ? args[argsProjectIndex + 1] : undefined // prettier-ignore
-const ignoreInclude = args.find(arg => ['-ii', '--ignoreInclude'].includes(arg)) // prettier-ignore
+const argsIgnoreIncludeIndex = args.findIndex(arg => ['-ii', '--ignoreInclude'].includes(arg)) // prettier-ignore
+const ignoreInclude = argsIgnoreIncludeIndex !== -1 // prettier-ignore
 
 const files = args.filter(file => /\.(ts|tsx)$/.test(file))
 if (files.length === 0) {
@@ -18,6 +19,7 @@ if (files.length === 0) {
 const remainingArgsToForward = args
   .slice()
   .splice(argsProjectIndex, 2)
+  .splice(argsIgnoreIncludeIndex, 2)
   .filter(arg => !files.includes(arg))
 
 // Load existing config

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ const { randomChars, resolveFromModule, resolveFromRoot } = require('./utils')
 const args = process.argv.slice(2)
 const argsProjectIndex = args.findIndex(arg => ['-p', '--project'].includes(arg)) // prettier-ignore
 const argsProjectValue = argsProjectIndex !== -1 ? args[argsProjectIndex + 1] : undefined // prettier-ignore
+const ignoreInclude = args.find(arg => ['-ii', '--ignoreInclude'].includes(arg)) // prettier-ignore
 
 const files = args.filter(file => /\.(ts|tsx)$/.test(file))
 if (files.length === 0) {
@@ -25,6 +26,11 @@ const tsconfigContent = fs.readFileSync(tsconfigPath).toString()
 // Use 'eval' to read the JSON as regular JavaScript syntax so that comments are allowed
 let tsconfig = {}
 eval(`tsconfig = ${tsconfigContent}`)
+
+if (ignoreInclude) {
+  const { include, ...restOfConfig } = tsconfig;
+  tsconfig = restOfConfig;
+}
 
 // Write a temp config file
 const tmpTsconfigPath = resolveFromRoot(`tsconfig.${randomChars()}.json`)


### PR DESCRIPTION
# Summary
This adds support for the use case specified in #9 

Obviously we can't forward this special argument onto TS, so it was removed. But at least this enables us to filter out the included files in the TS config.

Usage is `tsc-files -ii --noEmit`