### PR TITLE
Add resolved `typeRoots` into the discarded includes to maintain global types.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,16 @@ const tsconfigContent = fs.readFileSync(tsconfigPath).toString()
 let tsconfig = {}
 eval(`tsconfig = ${tsconfigContent}`)
 
+/**
+ * Because we we override the configs' `tsconfig.include`, grab some types to inject in.
+ * We then resolve them to the ROOT–this could be incorrect for a monorepo project.
+ * 
+ * IDEA/TODO: Should we allow injection of typeRoots via a CLI arg instead?
+ */
+const typeRoots = (tsconfig.compilerOptions ? tsconfig.compilerOptions.typeRoots : []).map(
+  file => resolveFromRoot(file)
+);
+
 // Write a temp config file
 const tmpTsconfigPath = resolveFromRoot(`tsconfig.${randomChars()}.json`)
 const tmpTsconfig = {
@@ -36,7 +46,7 @@ const tmpTsconfig = {
     skipLibCheck: true,
   },
   files,
-  include: [],
+  include: [...typeRoots], // remove everything from include except for types so we do not typecheck everything
 }
 fs.writeFileSync(tmpTsconfigPath, JSON.stringify(tmpTsconfig, null, 2))
 


### PR DESCRIPTION
This is an idea to fix https://github.com/gustavopch/tsc-files/issues/20.

Instead of discarding all includes, which discards required, global `.d.ts` type files, can we use the `typeRoots` a config may have setup instead?

For me, this basically results in:
```diff
-includes: [].
+includes: [
+  '/Users/…/repo/types',
+  '/Users/…/repo/node_modules/@types',
+],
```

**I don't think this quite hits the mark, however:**
 - Does everyone use `typeRoots` in this manner?  I do not know.
 - Likely will not work for a monorepo with nested tsconfig as files are resolved to the root.  Maybe `resolveFromRoot` is not even required..
 - Often `typeRoots` will import a fair bit, this could still include a large % of your codebase.  My `typeRoots` includes `node_modules/@types`.

Ultimately this may defeat the purpose https://github.com/gustavopch/tsc-files/pull/18 set out to resolve…but I guess this could be documented.  Alternatively, I might suggest you could pass `--typeRoots ./types/` or something via CLI, but I wasn't so comfortable implementing that with the `remainingArgsToForward` to be frank.