### PR TITLE
Allow -i or --include argument for custom include files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,15 +9,22 @@ const args = process.argv.slice(2)
 const argsProjectIndex = args.findIndex(arg => ['-p', '--project'].includes(arg)) // prettier-ignore
 const argsProjectValue = argsProjectIndex !== -1 ? args[argsProjectIndex + 1] : undefined // prettier-ignore
 
-const files = args.filter(file => /\.(ts|tsx)$/.test(file))
+const argsIncludeIndex = args.findIndex(arg => ['-i', '--include'].includes(arg)) // prettier-ignore
+const argsIncludeValue = argsIncludeIndex !== -1 ? args[argsIncludeIndex + 1] : undefined // prettier-ignore
+let argsIncludeValueArray = []
+
+const files = args.filter(file => /\.(ts|tsx)$/.test(file) && argsIncludeValue !== file)
 if (files.length === 0) {
   process.exit(0)
 }
 
-const remainingArgsToForward = args.slice().filter(arg => !files.includes(arg))
-
+let remainingArgsToForward = args.slice().filter(arg => !files.includes(arg))
 if (argsProjectIndex !== -1) {
-  remainingArgsToForward.splice(argsProjectIndex, 2)
+  remainingArgsToForward = remainingArgsToForward.filter(args => !['-p', '--project', argsProjectValue].includes(args))
+}
+if (argsIncludeIndex !== -1) {
+  remainingArgsToForward = remainingArgsToForward.filter(args => !['-i', '--include', argsIncludeValue].includes(args))
+  argsIncludeValueArray = argsIncludeValue.split(',')
 }
 
 // Load existing config
@@ -36,7 +43,7 @@ const tmpTsconfig = {
     skipLibCheck: true,
   },
   files,
-  include: [],
+  include: argsIncludeValueArray
 }
 fs.writeFileSync(tmpTsconfigPath, JSON.stringify(tmpTsconfig, null, 2))
 


### PR DESCRIPTION
Solution for #20 

Use with a single file or glob: `tsc-files -i ./dir/**/*.ts`
Use with a list of files, separated by coma: `tsc-files -i A.ts,B.ts`