### PR TITLE
Add support for typescript in the CheckJS mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ const args = process.argv.slice(2)
 const argsProjectIndex = args.findIndex(arg => ['-p', '--project'].includes(arg)) // prettier-ignore
 const argsProjectValue = argsProjectIndex !== -1 ? args[argsProjectIndex + 1] : undefined // prettier-ignore
 
-const files = args.filter(file => /\.(ts|tsx)$/.test(file))
+const files = args.filter(file => /\.(ts|tsx|js|jsx)$/.test(file))
 if (files.length === 0) {
   process.exit(0)
 }


### PR DESCRIPTION
In the checkJs mode, typescript will also check your JavaScript files using the types inside the JsDoc comments.

At the moment, you cannot pass a .js files to tsc-files, because it gives the following error:

    error TS5042: Option 'project' cannot be mixed with source files on a command line.

This is because the js files are appended after the tsc command. This commit allows the tsc-files plugin to also work with the checkJs mode