### PR TITLE
Fix for windows users with space in tsc path

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -73,16 +73,29 @@ for (const eventName of ['exit', 'SIGHUP', 'SIGINT', 'SIGTERM']) {
 }
 
 // Type-check our files
+
+// See: https://github.com/gustavopch/tsc-files/issues/44#issuecomment-1250783206
+let tscPath = process.versions.pnp
+  ? 'tsc'
+  : resolveFromModule(
+      'typescript',
+      `../.bin/tsc${process.platform === 'win32' ? '.cmd' : ''}`,
+    )
+let projectArg = tmpTsconfigPath
+
+if (process.platform === 'win32') {
+  if (tscPath.includes(' ')) {
+    tscPath = `"${tscPath}"`
+  }
+  if (projectArg.includes(' ')) {
+    projectArg = `"${projectArg}"`
+  }
+}
+
 const { status } = spawnSync(
-  // See: https://github.com/gustavopch/tsc-files/issues/44#issuecomment-1250783206
-  process.versions.pnp
-    ? 'tsc'
-    : resolveFromModule(
-        'typescript',
-        `../.bin/tsc${process.platform === 'win32' ? '.cmd' : ''}`,
-      ),
-  ['-p', tmpTsconfigPath, ...remainingArgsToForward],
-  { stdio: 'inherit' },
+  tscPath,
+  ['-p', projectArg, ...remainingArgsToForward],
+  { stdio: 'inherit', shell: process.platform === 'win32' },
 )
 
 process.exit(status)


### PR DESCRIPTION
This fixes the issue #60 which occurs when:
* The user is using windows
* The path to the user's `tsc.cmd` includes a space e.g 
  ```C:\Users\foohines\code\dir with space\node_modules\.bin\tsc.cmd```

This fix works by:
* Wrapping the `tscPath` in double quotes if it contains a space (passed as spawnSync's first argument)
* Wrapping the `projectArg` in double quotes if it contains a space (passed in spawnSync's second argument)
* Setting `{ shell: true }` option to spawnSync for windows users only 

More context can be found [in the node documentation](https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows) on how to correctly spawn windows .cmd files

