### PR TITLE
Fix github action badge url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tsc-files
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/gustavopch/tsc-files/Release?style=flat-square)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/gustavopch/tsc-files/release.yml?style=flat-square)
 
 A tiny tool to run `tsc` on specific files without ignoring `tsconfig.json`.
 


### PR DESCRIPTION
The github action badge url is out of date in the readme
old url: https://img.shields.io/github/workflow/status/gustavopch/tsc-files/Release?style=flat-square
new url: https://img.shields.io/github/actions/workflow/status/gustavopch/tsc-files/release.yml?style=flat-square