### PR TITLE
feat: handle checkJs property if set in tsconfig

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -27,6 +27,15 @@ const argsProjectValue =
   argsProjectIndex !== -1 ? args[argsProjectIndex + 1] : undefined
 
 const files = args.filter(file => /\.(ts|tsx)$/.test(file))
+const removeCommentsFromJson = fileContent => {
+  return fileContent.replaceAll(/[(\/\*)(\/\/)](.*)/g, '')
+}
+
+// Load existing config
+const tsconfigPath = argsProjectValue || resolveFromRoot('tsconfig.json')
+const fileContent = fs.readFileSync(tsconfigPath, 'utf-8')
+const tsconfig = JSON.parse(removeCommentsFromJson(fileContent))
+
 if (files.length === 0) {
   process.exit(0)
 }
@@ -36,13 +45,6 @@ const remainingArgsToForward = args.slice().filter(arg => !files.includes(arg))
 if (argsProjectIndex !== -1) {
   remainingArgsToForward.splice(argsProjectIndex, 2)
 }
-
-// Load existing config
-const tsconfigPath = argsProjectValue || resolveFromRoot('tsconfig.json')
-const tsconfigContent = fs.readFileSync(tsconfigPath).toString()
-// Use 'eval' to read the JSON as regular JavaScript syntax so that comments are allowed
-let tsconfig = {}
-eval(`tsconfig = ${tsconfigContent}`)
 
 // Write a temp config file
 const tmpTsconfigPath = resolveFromRoot(`tsconfig.${randomChars()}.json`)

--- a/cli.js
+++ b/cli.js
@@ -26,7 +26,6 @@ const argsProjectIndex = args.findIndex(arg =>
 const argsProjectValue =
   argsProjectIndex !== -1 ? args[argsProjectIndex + 1] : undefined
 
-const files = args.filter(file => /\.(ts|tsx)$/.test(file))
 const removeCommentsFromJson = fileContent => {
   return fileContent.replaceAll(/[(\/\*)(\/\/)](.*)/g, '')
 }
@@ -35,7 +34,16 @@ const removeCommentsFromJson = fileContent => {
 const tsconfigPath = argsProjectValue || resolveFromRoot('tsconfig.json')
 const fileContent = fs.readFileSync(tsconfigPath, 'utf-8')
 const tsconfig = JSON.parse(removeCommentsFromJson(fileContent))
+const {
+  compilerOptions: { checkJs },
+} = tsconfig
 
+const tsOnlyRegex = /\.(ts|tsx)$/
+const checkJsRegex = /\.(js|cjs|mjs|ts|tsx)$/
+
+const files = args.filter(file =>
+  checkJs ? checkJsRegex.test(file) : tsOnlyRegex.test(file),
+)
 if (files.length === 0) {
   process.exit(0)
 }


### PR DESCRIPTION
if the `tsconfig.json` contains the property `checkJs: true`, javascript files are not checked by tsc-files since the files filters do ignore file extensions other than `ts` and `tsx`. However, since `checkJs` should include all valid javascript file extensions, it is expected that it will respect the setting of the `tsconfig.json` and take the additional file extensions `js`, `cjs` and `mjs` into account.