### PR TITLE
fix tsconfig file with emitDeclarationOnly flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -50,6 +50,7 @@ const tmpTsconfig = {
   ...tsconfig,
   compilerOptions: {
     ...tsconfig.compilerOptions,
+    emitDeclarationOnly: false,
     skipLibCheck: true,
   },
   files,


### PR DESCRIPTION
if emitDeclarationOnly flag is set in the project tsconfig file the tsc-files command will fail in combination with the --noEmit flag since these two options aren't combinable.