### PR TITLE
Update cli.js

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -82,7 +82,7 @@ const { status } = spawnSync(
         `../.bin/tsc${process.platform === 'win32' ? '.cmd' : ''}`,
       ),
   ['-p', tmpTsconfigPath, ...remainingArgsToForward],
-  { stdio: 'inherit' },
+  { stdio: 'inherit', shell: ${process.platform === 'win32' ? true : undefined} }, // Win32 seems to require a shell for running tsc...
 )
 
 process.exit(status)

--- a/cli.js
+++ b/cli.js
@@ -82,7 +82,7 @@ const { status } = spawnSync(
         `../.bin/tsc${process.platform === 'win32' ? '.cmd' : ''}`,
       ),
   ['-p', tmpTsconfigPath, ...remainingArgsToForward],
-  { stdio: 'inherit', shell: ${process.platform === 'win32' ? true : undefined} }, // Win32 seems to require a shell for running tsc...
+  { stdio: 'inherit', shell: process.platform === 'win32' ? true : undefined }, // Win32 seems to require a shell for running tsc...
 )
 
 process.exit(status)


### PR DESCRIPTION
Hi!

I was encountering an error where on my windows machine, pre-commit hooks were not performing type checks. It appeared to work on my Mac laptop.

I am not sure if this is a Windows idiosyncrasy or because of new node versions, but I had to run `tsc` with shell: true whilst spawning the sub-process.

Node ver: v22.15.0
OS: Windows 10